### PR TITLE
Move to min after homing instead of max

### DIFF
--- a/Software/platformio.ini
+++ b/Software/platformio.ini
@@ -17,7 +17,8 @@ build_flags =
     -D CORE_DEBUG_LEVEL=4
 
 lib_deps =
-    https://github.com/theelims/StrokeEngine.git
+;    https://github.com/theelims/StrokeEngine.git
+    https://github.com/denialtek/StrokeEngine
     https://github.com/tzapu/WiFiManager.git
     gin66/FastAccelStepper@^0.30.8
     pkerspe/ESP-FlexyStepper@^1.4.9

--- a/Software/src/Stroke_Engine_Helper.h
+++ b/Software/src/Stroke_Engine_Helper.h
@@ -24,7 +24,7 @@ static motorProperties servoMotor{
     .maxSpeed = 60 * (hardcode_maxSpeedMmPerSecond / (hardcode_pulleyToothCount * hardcode_beltPitchMm)),
     .maxAcceleration = 10000,
     .stepsPerMillimeter = hardcode_motorStepPerRevolution / (hardcode_pulleyToothCount * hardcode_beltPitchMm),
-    .invertDirection = true,
+    .invertDirection = false,
     .enableActiveLow = true,
     .stepPin = MOTOR_STEP_PIN,
     .directionPin = MOTOR_DIRECTION_PIN,

--- a/Software/src/Utilities.cpp
+++ b/Software/src/Utilities.cpp
@@ -154,7 +154,8 @@ void OSSM::startStrokeEngine()
     Stroker.setPattern(int(strokePattern), true);
     Stroker.setDepth(0.01f * depthPercentage * abs(maxStrokeLengthMm), true);
     Stroker.setStroke(0.01f * strokePercentage * abs(maxStrokeLengthMm), true);
-    Stroker.moveToMax(10 * 3);
+    //Stroker.moveToMax(10 * 3);
+    Stroker.moveToMin(10 * 3);  //armpit 02.09.2024 - This corrects "moving to full depth after homing" issue
     Serial.println(Stroker.getState());
 
     strokerPatternName = Stroker.getPatternName(strokePattern); // Set the initial stroke engine pattern name
@@ -188,7 +189,7 @@ void OSSM::startStrokeEngine()
                 Stroker.setPattern(int(strokePattern), false); // Pattern, index must be < Stroker.getNumberOfPattern()
             }
 
-            
+
             if (buttonPressCount > 1)   // Enter pattern-selection mode if the button is pressed more than once
             {
                 rightKnobMode = MODE_PATTERN;

--- a/Software/src/Utilities.h
+++ b/Software/src/Utilities.h
@@ -71,7 +71,7 @@ class OSSM
     bool wifiControlActive = false;
 
     float speedPercentage = 0;   // percentage 0-100
-    float depthPercentage = 100; // percentage 0-100
+    float depthPercentage = 50; // percentage 0-100
     float strokePercentage = 10; // percentage 0-100
     bool isStopped = false;
     float sensationPercentage = 40; // percentage 0-100, maps to sensation -100 - 100, so 40 default = -20 sensation
@@ -83,6 +83,8 @@ class OSSM
 
     String strokerPatternName = "Default";  // The name of the current stroke engine pattern
 
+    StrokeEngine Stroker;
+
     OSSM()
         : g_encoder(ENCODER_A, ENCODER_B),
           g_ui() // this just creates the objects with parameters
@@ -91,6 +93,7 @@ class OSSM
 
     void setup();
     void handleStopCondition(); // handles e-stop condition
+    void startStrokeEngine();   // Starts Stroke Engine running
     [[noreturn]] void runPenetrate();        // runs actual penetration motion one cycle
     [[noreturn]] void runStrokeEngine();     // runs stroke Engine
     String getPatternJSON(StrokeEngine Stroker);

--- a/Software/src/main.cpp
+++ b/Software/src/main.cpp
@@ -89,9 +89,8 @@ void setup()
                             0);                   /* pin task to core 0 */
     delay(100);
 
-    ossm.findHome();
-
-    //ossm.setRunMode();
+    // Start Stroke Engine and home the machine sensorless
+    ossm.startStrokeEngine();
 
     // Kick off the http and motion tasks - they begin executing as soon as they
     // are created here! Do not change the priority of the task, or do so with


### PR DESCRIPTION
Corrects a bug in the runStrokeEngine procedure where it's intentionally setting it to full depth which matches the (undesired, we agree?) behavior.